### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # nwanime-dl Anime Downloader   
 ## Downloads anime from http://www.nwanime.com/                             
-[![Supported Python versions](https://pypip.in/py_versions/nwanime_dl/badge.svg)](https://pypi.python.org/pypi/<nwanime_dl>/)
-[![License](https://pypip.in/license/nwanime_dl/badge.svg)](https://pypi.python.org/pypi/nwanime_dl/)
-[![Development Status](https://pypip.in/status/nwanime_dl/badge.svg)](https://pypi.python.org/pypi/nwanime_dl/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/nwanime_dl.svg)](https://pypi.python.org/pypi/<nwanime_dl>/)
+[![License](https://img.shields.io/pypi/l/nwanime_dl.svg)](https://pypi.python.org/pypi/nwanime_dl/)
+[![Development Status](https://img.shields.io/pypi/status/nwanime_dl.svg)](https://pypi.python.org/pypi/nwanime_dl/)
 
 ###Note: Currently works only for linux and mac as it uses wget for the final download.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20nwanime-dl))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `nwanime-dl`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.